### PR TITLE
Unifies the seekers playermodel config

### DIFF
--- a/gamemodes/guesswho/gamemode/player_class/player_seeker.lua
+++ b/gamemodes/guesswho/gamemode/player_class/player_seeker.lua
@@ -8,19 +8,26 @@ PLAYER.JumpPower            = 200
 PLAYER.CanUseFlashlight     = true
 
 function PLAYER:SetModel()
-
-    local model = "models/player/combine_super_soldier.mdl"
-
     if GetConVar( "gw_disguise_seeker" ):GetBool() then
         local models = GAMEMODE.Models
 
         local rand = math.random(1,#models)
 
         model = models[rand]
-    end
 
-    util.PrecacheModel( model )
-    self.Player:SetModel( model )
+        util.PrecacheModel( model )
+        self.Player:SetModel( model )
+    else
+
+      local models = GAMEODE.SeekerModels
+      local rand = math.random(1,#models)
+
+      model = models[rand]
+
+      util.PrecacheModel( model )
+      self.Player:SetModel( model )
+
+    end
 
 end
 

--- a/gamemodes/guesswho/gamemode/round.lua
+++ b/gamemodes/guesswho/gamemode/round.lua
@@ -82,7 +82,8 @@ function GM:RoundCreateWalkers()
 end
 
 function GM:RoundStart()
-
+    hook.Call( "GWOnRoundStart" )
+    
     for k,v in pairs(team.GetPlayers( TEAM_SEEKING )) do
         v:Freeze( false )
         v:SetAvoidPlayers( false )

--- a/gamemodes/guesswho/gamemode/sh_config.lua
+++ b/gamemodes/guesswho/gamemode/sh_config.lua
@@ -22,6 +22,10 @@ GM.Models = {
     "models/player/Group01/Female_03.mdl",
 }
 
+GM.SeekerModels = {
+  "models/player/combine_super_soldier.mdl"
+}
+
 GM.Weapons = {
     "weapon_gw_prophunt",
     "weapon_gw_barricade",


### PR DESCRIPTION
This moves the config for seekers player models into the sh_config.lua file and also adds the ability for multiple player models rather than just the one or the hiding player models.
